### PR TITLE
remove unused #[macro_use]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ extern crate alloc;
 #[macro_use]
 extern crate collections;
 
-#[macro_use]
 extern crate bitflags;
 extern crate goblin;
 extern crate spin;


### PR DESCRIPTION
Otherwise, compilation fails with:

```
   Compiling kernel v0.1.0 (file:///home/corentih/rust/redox/kernel)
error: unused `#[macro_use]` import
  --> kernel/src/lib.rs:40:1
   |
40 | #[macro_use]
   | ^^^^^^^^^^^^
   |
note: lint level defined here
  --> kernel/src/lib.rs:6:9
   |
6  | #![deny(warnings)]
   |         ^^^^^^^^

error: aborting due to previous error

error: Could not compile `kernel`.
```