### PR TITLE
Prevent cpuid get_extended_function_info panic

### DIFF
--- a/arch/x86_64/Cargo.toml
+++ b/arch/x86_64/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 [dependencies]
 alloc_kernel = { path = "../../alloc_kernel/" }
 bitflags = "0.7"
-raw-cpuid = "2.0"
+raw-cpuid = { git = "https://github.com/gz/rust-cpuid", branch = "master" }
 spin = "0.4"
 redox_syscall = "0.1"
 


### PR DESCRIPTION
A kernel panic occurs on some CPUs (notably qemu-system-x86_64) when
calling rust-cpuid's get_extended_function_info.  This is fixed upstream
in commit c3ebfc553cdff98d19d29777fd85c4f9182bfb66 but has yet to make
it crates.io.

The panic can by triggered by running "ls sys:" from ion and causes
redox to become unresponsive.