### PR TITLE
Implemented reading from RTC Century counter in x86_64 arch, if available

### DIFF
--- a/arch/x86_64/src/device/mod.rs
+++ b/arch/x86_64/src/device/mod.rs
@@ -9,6 +9,9 @@ pub mod serial;
 pub unsafe fn init(active_table: &mut ActivePageTable){
     pic::init();
     local_apic::init(active_table);
+}
+
+pub unsafe fn init_noncore() {
     rtc::init();
     serial::init();
 }

--- a/arch/x86_64/src/start.rs
+++ b/arch/x86_64/src/start.rs
@@ -113,12 +113,15 @@ pub unsafe extern fn kstart() -> ! {
             // Init the allocator
             allocator::init(::KERNEL_HEAP_OFFSET, ::KERNEL_HEAP_SIZE);
         }
-
+        
         // Initialize devices
         device::init(&mut active_table);
 
         // Read ACPI tables, starts APs
         acpi::init(&mut active_table);
+
+        // Initialize all of the non-core devices not otherwise needed to complete initialization
+        device::init_noncore();
 
         BSP_READY.store(true, Ordering::SeqCst);
     }


### PR DESCRIPTION
The ACPI code now saves the FADT in a globally accessible mutex, with infrastructure in place to add additional tables to the mutex if necessary.

The x86_64 device initialization has been split into "core" devices necessary for initialization, and "non-core" devices not necessary to bring the kernel up, which are initialized, respectively, before and after ACPI.

The RTC read function now checks for the presence of the FADT, and, if present, uses the century register indicated in the table. If not present, it defaults to assuming the 21st century as before.