### PR TITLE
Fix the listing of `initfs:` directories

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -66,6 +66,7 @@ fn fill_from_location(f: &mut fs::File, loc: &Path ) -> Result<(), (Error)> {
         let sub = folders.get(*dir).unwrap();
         let mut first = true;
         for child in sub.iter() {
+            let idx = child.rfind('/').unwrap() + 1;
             let (_, c) = child.split_at(idx);
             if first {
                 write!(f, "{}", c)?;


### PR DESCRIPTION
There was a bug at the `initfs` generation which made the listing of the contents of the `initfs:`subdirectories impossible from the command line.

The subdirectory listing data had the full paths of the files (like `bin/ahcid\nbin/bgad\n...`) when it should just only be the names of the files (`ahcid\nbgad\n...`)