### PR TITLE
Fix PIT Interrupt Not Context Switching [irq]

### DIFF
--- a/src/interrupt/irq.rs
+++ b/src/interrupt/irq.rs
@@ -6,7 +6,8 @@ use core::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use time;
 use context;
 
-static PIT_TICKS: AtomicUsize = ATOMIC_USIZE_INIT;
+//resets to 0 in context::switch()
+pub static PIT_TICKS: AtomicUsize = ATOMIC_USIZE_INIT;
 
 unsafe fn trigger(irq: u8) {
     extern {
@@ -52,8 +53,6 @@ interrupt!(pit, {
     pic::MASTER.ack();
 
     if PIT_TICKS.fetch_add(1, Ordering::SeqCst) >= 10 {
-        PIT_TICKS.store(0, Ordering::SeqCst);
-        assert_eq!(PIT_TICKS.load(Ordering::SeqCst), 0);
         context::switch();
     }
 

--- a/src/interrupt/irq.rs
+++ b/src/interrupt/irq.rs
@@ -51,7 +51,9 @@ interrupt!(pit, {
 
     pic::MASTER.ack();
 
-    if PIT_TICKS.fetch_add(1, Ordering::SeqCst) % 10 == 0 {
+    if PIT_TICKS.fetch_add(1, Ordering::SeqCst) >= 10 {
+        PIT_TICKS.store(0, Ordering::SeqCst);
+        assert_eq!(PIT_TICKS.load(Ordering::SeqCst), 0);
         context::switch();
     }
 


### PR DESCRIPTION
PIT interrupt should context switch or else all of Redox crashes.
This will fix programs like the Snake game crashing all of Redox.
A global AtomicUSize counter was added, and a line to switch contexts
on every 10 PIT interrupts in irq.rs.

This fixes https://github.com/redox-os/redox/issues/781 (Snake Game crashes Redox #781) (Tested)