### PR TITLE
Pass empty second argument to dup() call in clone

### DIFF
--- a/src/syscall/process.rs
+++ b/src/syscall/process.rs
@@ -267,7 +267,7 @@ pub fn clone(flags: usize, stack_base: usize) -> Result<ContextId> {
                             let scheme = schemes.get(file.scheme).ok_or(Error::new(EBADF))?;
                             scheme.clone()
                         };
-                        scheme.dup(file.number, b"clone")
+                        scheme.dup(file.number, b"")
                     };
                     match result {
                         Ok(new_number) => {


### PR DESCRIPTION
I don't know if this was there for a reason, but it was making the dup() fail with tcpd, and I don't seem this being handled specially in redoxfs or anywhere else.

This seems to have been the cause for one issue I was having with `git`; it was somewhat cryptic since the actual call that was failing (the dup itself) wasn't listed in the log of the program's system calls, and I think earlier I missed the fact that the failing read was in another process that had forked.