### PR TITLE
Revert "pipe: make read() return when write end is closed"

### DIFF
--- a/src/scheme/pipe.rs
+++ b/src/scheme/pipe.rs
@@ -172,8 +172,6 @@ impl PipeRead {
     }
 
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        let mut resumed = false;
-
         loop {
             {
                 let mut vec = self.vec.lock();
@@ -188,7 +186,7 @@ impl PipeRead {
                     }
                 }
 
-                if i > 0 || resumed {
+                if i > 0 {
                     return Ok(i);
                 }
             }
@@ -199,7 +197,6 @@ impl PipeRead {
                 return Err(Error::new(EAGAIN));
             } else {
                 self.condition.wait();
-                resumed = true;
             }
         }
     }
@@ -249,9 +246,7 @@ impl PipeWrite {
                     vec.push_back(b);
                 }
 
-                if buf.len() > 0 {
-                    self.condition.notify();
-                }
+                self.condition.notify();
 
                 Ok(buf.len())
             } else {


### PR DESCRIPTION
Oops, this was incorrect. The `weak_count` test handles this, and this change causes it to return EOF when any file descriptor is dropped, if there are several.

The real cause of the issue I had was because it failed to set `O_CLOEXEC` with `fcntl()`, which wasn't clear because it didn't make any system call (since that function wasn't implemented in newlib) and git wasn't checking the return value. That is addressed in https://github.com/redox-os/newlib/pull/40.