### PR TITLE
Make dup2() work if second file descriptor doesn't exist

### DIFF
--- a/src/syscall/fs.rs
+++ b/src/syscall/fs.rs
@@ -272,7 +272,7 @@ pub fn dup2(fd: FileHandle, new_fd: FileHandle, buf: &[u8]) -> Result<FileHandle
     if fd == new_fd {
         Ok(new_fd)
     } else {
-        let _ = close(new_fd)?;
+        let _ = close(new_fd);
 
         let file = {
             let contexts = context::contexts();


### PR DESCRIPTION
The code I was dealing with for some reason closed the second file descriptor before dup2, but that should be valid.

The `?` here may be accidental, given the `let _ =`.