### PR TITLE
Strip extra slashes from path

### DIFF
--- a/src/context/context.rs
+++ b/src/context/context.rs
@@ -189,6 +189,7 @@ impl Context {
                     }
                 })
                 .filter_map(|x| x)
+                .filter(|x| !x.is_empty())
                 .collect::<Vec<_>>();
             parts
                 .iter()


### PR DESCRIPTION
Fixes strange behavior like 'cd .//////; pwd'