### PR TITLE
Update to `bitflags` version 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "alloc_kernel 0.1.0",
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-cpuid 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.31",
@@ -22,6 +22,11 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -92,6 +97,7 @@ dependencies = [
 
 [metadata]
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum goblin 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81af14056c25d33759862c5ae2035452acb1255bfb1b16db57819f183921e259"
 "checksum linked_list_allocator 0.4.1 (git+https://github.com/redox-os/linked-list-allocator.git)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 alloc_kernel = { path = "alloc_kernel" }
-bitflags = "0.7"
+bitflags = "1"
 spin = "0.4"
 raw-cpuid = "3.0"
 redox_syscall = { path = "syscall" }

--- a/src/acpi/dmar/mod.rs
+++ b/src/acpi/dmar/mod.rs
@@ -3,7 +3,8 @@ use core::mem;
 use super::sdt::Sdt;
 use self::drhd::Drhd;
 use memory::Frame;
-use paging::{entry, ActivePageTable, PhysicalAddress};
+use paging::{ActivePageTable, PhysicalAddress};
+use paging::entry::EntryFlags;
 
 use super::{find_sdt, load_table, get_sdt_signature};
 
@@ -93,7 +94,7 @@ pub struct DmarDrhd {
 
 impl DmarDrhd {
     pub fn get(&self, active_table: &mut ActivePageTable) -> &'static mut Drhd {
-        let result = active_table.identity_map(Frame::containing_address(PhysicalAddress::new(self.base as usize)), entry::PRESENT | entry::WRITABLE | entry::NO_EXECUTE);
+        let result = active_table.identity_map(Frame::containing_address(PhysicalAddress::new(self.base as usize)), EntryFlags::PRESENT | EntryFlags::WRITABLE | EntryFlags::NO_EXECUTE);
         result.flush(active_table);
         unsafe { &mut *(self.base as *mut Drhd) }
     }

--- a/src/acpi/hpet.rs
+++ b/src/acpi/hpet.rs
@@ -3,7 +3,8 @@ use core::{mem, ptr};
 use core::intrinsics::{volatile_load, volatile_store};
 
 use memory::Frame;
-use paging::{entry, ActivePageTable, PhysicalAddress, Page, VirtualAddress};
+use paging::{ActivePageTable, PhysicalAddress, Page, VirtualAddress};
+use paging::entry::EntryFlags;
 
 use super::sdt::Sdt;
 use super::{ACPI_TABLE, find_sdt, load_table, get_sdt_signature};
@@ -68,7 +69,7 @@ impl GenericAddressStructure {
     pub unsafe fn init(&self, active_table: &mut ActivePageTable) {
         let page = Page::containing_address(VirtualAddress::new(self.address as usize));
         let frame = Frame::containing_address(PhysicalAddress::new(self.address as usize));
-        let result = active_table.map_to(page, frame, entry::PRESENT | entry::WRITABLE | entry::NO_EXECUTE);
+        let result = active_table.map_to(page, frame, EntryFlags::PRESENT | EntryFlags::WRITABLE | EntryFlags::NO_EXECUTE);
         result.flush(active_table);
     }
 

--- a/src/acpi/madt.rs
+++ b/src/acpi/madt.rs
@@ -1,7 +1,8 @@
 use core::mem;
 
 use memory::{allocate_frames, Frame};
-use paging::{entry, ActivePageTable, Page, PhysicalAddress, VirtualAddress};
+use paging::{ActivePageTable, Page, PhysicalAddress, VirtualAddress};
+use paging::entry::EntryFlags;
 
 use super::sdt::Sdt;
 use super::{AP_STARTUP, TRAMPOLINE, find_sdt, load_table, get_sdt_signature};
@@ -49,7 +50,7 @@ impl Madt {
                 let trampoline_page = Page::containing_address(VirtualAddress::new(TRAMPOLINE));
 
                 // Map trampoline
-                let result = active_table.map_to(trampoline_page, trampoline_frame, entry::PRESENT | entry::WRITABLE);
+                let result = active_table.map_to(trampoline_page, trampoline_frame, EntryFlags::PRESENT | EntryFlags::WRITABLE);
                 result.flush(active_table);
 
                 for madt_entry in madt.iter() {

--- a/src/acpi/mod.rs
+++ b/src/acpi/mod.rs
@@ -13,7 +13,8 @@ use spin::RwLock;
 use stop::kstop;
 
 use memory::Frame;
-use paging::{entry, ActivePageTable, Page, PhysicalAddress, VirtualAddress};
+use paging::{ActivePageTable, Page, PhysicalAddress, VirtualAddress};
+use paging::entry::EntryFlags;
 
 use self::dmar::Dmar;
 use self::fadt::Fadt;
@@ -46,7 +47,7 @@ fn get_sdt(sdt_address: usize, active_table: &mut ActivePageTable) -> &'static S
         let page = Page::containing_address(VirtualAddress::new(sdt_address));
         if active_table.translate_page(page).is_none() {
             let frame = Frame::containing_address(PhysicalAddress::new(page.start_address().get()));
-            let result = active_table.map_to(page, frame, entry::PRESENT | entry::NO_EXECUTE);
+            let result = active_table.map_to(page, frame, EntryFlags::PRESENT | EntryFlags::NO_EXECUTE);
             result.flush(active_table);
         }
     }
@@ -60,7 +61,7 @@ fn get_sdt(sdt_address: usize, active_table: &mut ActivePageTable) -> &'static S
         for page in Page::range_inclusive(start_page, end_page) {
             if active_table.translate_page(page).is_none() {
                 let frame = Frame::containing_address(PhysicalAddress::new(page.start_address().get()));
-                let result = active_table.map_to(page, frame, entry::PRESENT | entry::NO_EXECUTE);
+                let result = active_table.map_to(page, frame, EntryFlags::PRESENT | EntryFlags::NO_EXECUTE);
                 result.flush(active_table);
             }
         }

--- a/src/acpi/rsdp.rs
+++ b/src/acpi/rsdp.rs
@@ -1,5 +1,6 @@
 use memory::Frame;
-use paging::{entry, ActivePageTable, Page, PhysicalAddress, VirtualAddress};
+use paging::{ActivePageTable, Page, PhysicalAddress, VirtualAddress};
+use paging::entry::EntryFlags;
 
 /// RSDP
 #[derive(Copy, Clone, Debug)]
@@ -28,7 +29,7 @@ impl RSDP {
             let end_frame = Frame::containing_address(PhysicalAddress::new(end_addr));
             for frame in Frame::range_inclusive(start_frame, end_frame) {
                 let page = Page::containing_address(VirtualAddress::new(frame.start_address().get()));
-                let result = active_table.map_to(page, frame, entry::PRESENT | entry::NO_EXECUTE);
+                let result = active_table.map_to(page, frame, EntryFlags::PRESENT | EntryFlags::NO_EXECUTE);
                 result.flush(active_table);
             }
         }

--- a/src/arch/x86_64/device/local_apic.rs
+++ b/src/arch/x86_64/device/local_apic.rs
@@ -3,7 +3,8 @@ use x86::cpuid::CpuId;
 use x86::msr::*;
 
 use memory::Frame;
-use paging::{entry, ActivePageTable, PhysicalAddress, Page, VirtualAddress};
+use paging::{ActivePageTable, PhysicalAddress, Page, VirtualAddress};
+use paging::entry::EntryFlags;
 
 pub static mut LOCAL_APIC: LocalApic = LocalApic {
     address: 0,
@@ -32,7 +33,7 @@ impl LocalApic {
         if ! self.x2 {
             let page = Page::containing_address(VirtualAddress::new(self.address));
             let frame = Frame::containing_address(PhysicalAddress::new(self.address - ::KERNEL_OFFSET));
-            let result = active_table.map_to(page, frame, entry::PRESENT | entry::WRITABLE | entry::NO_EXECUTE);
+            let result = active_table.map_to(page, frame, EntryFlags::PRESENT | EntryFlags::WRITABLE | EntryFlags::NO_EXECUTE);
             result.flush(active_table);
         }
 

--- a/src/arch/x86_64/idt.rs
+++ b/src/arch/x86_64/idt.rs
@@ -63,21 +63,21 @@ pub unsafe fn init() {
 
     // Set syscall function
     IDT[0x80].set_func(syscall::syscall);
-    IDT[0x80].set_flags(IDT_PRESENT | IDT_RING_3 | IDT_INTERRUPT);
+    IDT[0x80].set_flags(IdtFlags::PRESENT | IdtFlags::RING_3 | IdtFlags::INTERRUPT);
 
     dtables::lidt(&IDTR);
 }
 
 bitflags! {
-    pub flags IdtFlags: u8 {
-        const IDT_PRESENT = 1 << 7,
-        const IDT_RING_0 = 0 << 5,
-        const IDT_RING_1 = 1 << 5,
-        const IDT_RING_2 = 2 << 5,
-        const IDT_RING_3 = 3 << 5,
-        const IDT_SS = 1 << 4,
-        const IDT_INTERRUPT = 0xE,
-        const IDT_TRAP = 0xF,
+    pub struct IdtFlags: u8 {
+        const PRESENT = 1 << 7;
+        const RING_0 = 0 << 5;
+        const RING_1 = 1 << 5;
+        const RING_2 = 2 << 5;
+        const RING_3 = 3 << 5;
+        const SS = 1 << 4;
+        const INTERRUPT = 0xE;
+        const TRAP = 0xF;
     }
 }
 
@@ -119,7 +119,7 @@ impl IdtEntry {
 
     // A function to set the offset more easily
     pub fn set_func(&mut self, func: unsafe extern fn()) {
-        self.set_flags(IDT_PRESENT | IDT_RING_0 | IDT_INTERRUPT);
+        self.set_flags(IdtFlags::PRESENT | IdtFlags::RING_0 | IdtFlags::INTERRUPT);
         self.set_offset(8, func as usize);
     }
 }

--- a/src/arch/x86_64/paging/entry.rs
+++ b/src/arch/x86_64/paging/entry.rs
@@ -9,17 +9,17 @@ use super::PhysicalAddress;
 pub struct Entry(u64);
 
 bitflags! {
-    pub flags EntryFlags: u64 {
-        const PRESENT =         1 << 0,
-        const WRITABLE =        1 << 1,
-        const USER_ACCESSIBLE = 1 << 2,
-        const WRITE_THROUGH =   1 << 3,
-        const NO_CACHE =        1 << 4,
-        const ACCESSED =        1 << 5,
-        const DIRTY =           1 << 6,
-        const HUGE_PAGE =       1 << 7,
-        const GLOBAL =          1 << 8,
-        const NO_EXECUTE =      1 << 63,
+    pub struct EntryFlags: u64 {
+        const PRESENT =         1 << 0;
+        const WRITABLE =        1 << 1;
+        const USER_ACCESSIBLE = 1 << 2;
+        const WRITE_THROUGH =   1 << 3;
+        const NO_CACHE =        1 << 4;
+        const ACCESSED =        1 << 5;
+        const DIRTY =           1 << 6;
+        const HUGE_PAGE =       1 << 7;
+        const GLOBAL =          1 << 8;
+        const NO_EXECUTE =      1 << 63;
     }
 }
 
@@ -48,7 +48,7 @@ impl Entry {
 
     /// Get the associated frame, if available
     pub fn pointed_frame(&self) -> Option<Frame> {
-        if self.flags().contains(PRESENT) {
+        if self.flags().contains(EntryFlags::PRESENT) {
             Some(Frame::containing_address(self.address()))
         } else {
             None

--- a/src/arch/x86_64/paging/mapper.rs
+++ b/src/arch/x86_64/paging/mapper.rs
@@ -4,7 +4,7 @@ use core::ptr::Unique;
 use memory::{allocate_frames, deallocate_frames, Frame};
 
 use super::{ActivePageTable, Page, PAGE_SIZE, PhysicalAddress, VirtualAddress};
-use super::entry::{self, EntryFlags};
+use super::entry::EntryFlags;
 use super::table::{self, Table, Level4};
 
 /// In order to enforce correct paging operations in the kernel, these types
@@ -107,7 +107,7 @@ impl Mapper {
             page.start_address().get(),
             p1[page.p1_index()].address().get(), p1[page.p1_index()].flags(),
             frame.start_address().get(), flags);
-        p1[page.p1_index()].set(frame, flags | entry::PRESENT);
+        p1[page.p1_index()].set(frame, flags | EntryFlags::PRESENT);
         MapperFlush::new(page)
     }
 
@@ -123,7 +123,7 @@ impl Mapper {
         let p2 = p3.next_table_mut(page.p3_index()).expect("failed to remap: no p2");
         let p1 = p2.next_table_mut(page.p2_index()).expect("failed to remap: no p1");
         let frame = p1[page.p1_index()].pointed_frame().expect("failed to remap: not mapped");
-        p1[page.p1_index()].set(frame, flags | entry::PRESENT);
+        p1[page.p1_index()].set(frame, flags | EntryFlags::PRESENT);
         MapperFlush::new(page)
     }
 

--- a/src/arch/x86_64/start.rs
+++ b/src/arch/x86_64/start.rs
@@ -13,7 +13,8 @@ use gdt;
 use idt;
 use interrupt;
 use memory;
-use paging::{self, entry, Page, VirtualAddress};
+use paging::{self, Page, VirtualAddress};
+use paging::entry::EntryFlags;
 use paging::mapper::MapperFlushAll;
 
 /// Test of zero values in BSS.
@@ -104,7 +105,7 @@ pub unsafe extern fn kstart(args_ptr: *const KernelArgs) -> ! {
             let heap_start_page = Page::containing_address(VirtualAddress::new(::KERNEL_HEAP_OFFSET));
             let heap_end_page = Page::containing_address(VirtualAddress::new(::KERNEL_HEAP_OFFSET + ::KERNEL_HEAP_SIZE-1));
             for page in Page::range_inclusive(heap_start_page, heap_end_page) {
-                let result = active_table.map(page, entry::PRESENT | entry::GLOBAL | entry::WRITABLE | entry::NO_EXECUTE);
+                let result = active_table.map(page, EntryFlags::PRESENT | EntryFlags::GLOBAL | EntryFlags::WRITABLE | EntryFlags::NO_EXECUTE);
                 flush_all.consume(result);
             }
 

--- a/src/context/memory.rs
+++ b/src/context/memory.rs
@@ -5,7 +5,7 @@ use spin::Mutex;
 
 use memory::Frame;
 use paging::{ActivePageTable, InactivePageTable, Page, PageIter, PhysicalAddress, VirtualAddress};
-use paging::entry::{self, EntryFlags};
+use paging::entry::EntryFlags;
 use paging::mapper::MapperFlushAll;
 use paging::temporary_page::TemporaryPage;
 
@@ -212,7 +212,7 @@ impl Memory {
         flush_all.flush(&mut active_table);
 
         if clear {
-            assert!(self.flags.contains(entry::WRITABLE));
+            assert!(self.flags.contains(EntryFlags::WRITABLE));
             unsafe {
                 intrinsics::write_bytes(self.start_address().get() as *mut u8, 0, self.size);
             }

--- a/src/devices/uart_16550.rs
+++ b/src/devices/uart_16550.rs
@@ -5,21 +5,21 @@ use syscall::io::{Io, Pio, Mmio, ReadOnly};
 
 bitflags! {
     /// Interrupt enable flags
-    flags IntEnFlags: u8 {
-        const RECEIVED = 1,
-        const SENT = 1 << 1,
-        const ERRORED = 1 << 2,
-        const STATUS_CHANGE = 1 << 3,
+    struct IntEnFlags: u8 {
+        const RECEIVED = 1;
+        const SENT = 1 << 1;
+        const ERRORED = 1 << 2;
+        const STATUS_CHANGE = 1 << 3;
         // 4 to 7 are unused
     }
 }
 
 bitflags! {
     /// Line status flags
-    flags LineStsFlags: u8 {
-        const INPUT_FULL = 1,
+    struct LineStsFlags: u8 {
+        const INPUT_FULL = 1;
         // 1 to 4 unknown
-        const OUTPUT_EMPTY = 1 << 5,
+        const OUTPUT_EMPTY = 1 << 5;
         // 6 and 7 unknown
     }
 }
@@ -88,7 +88,7 @@ impl<T: Io<Value = u8>> SerialPort<T> {
     }
 
     pub fn receive(&mut self) {
-        while self.line_sts().contains(INPUT_FULL) {
+        while self.line_sts().contains(LineStsFlags::INPUT_FULL) {
             debug_input(self.data.read());
         }
     }
@@ -96,15 +96,15 @@ impl<T: Io<Value = u8>> SerialPort<T> {
     pub fn send(&mut self, data: u8) {
         match data {
             8 | 0x7F => {
-                while ! self.line_sts().contains(OUTPUT_EMPTY) {}
+                while ! self.line_sts().contains(LineStsFlags::OUTPUT_EMPTY) {}
                 self.data.write(8);
-                while ! self.line_sts().contains(OUTPUT_EMPTY) {}
+                while ! self.line_sts().contains(LineStsFlags::OUTPUT_EMPTY) {}
                 self.data.write(b' ');
-                while ! self.line_sts().contains(OUTPUT_EMPTY) {}
+                while ! self.line_sts().contains(LineStsFlags::OUTPUT_EMPTY) {}
                 self.data.write(8);
             },
             _ => {
-                while ! self.line_sts().contains(OUTPUT_EMPTY) {}
+                while ! self.line_sts().contains(LineStsFlags::OUTPUT_EMPTY) {}
                 self.data.write(data);
             }
         }

--- a/src/scheme/user.rs
+++ b/src/scheme/user.rs
@@ -5,7 +5,8 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use core::{mem, slice, usize};
 use spin::{Mutex, RwLock};
 
-use paging::{InactivePageTable, Page, VirtualAddress, entry};
+use paging::{InactivePageTable, Page, VirtualAddress};
+use paging::entry::EntryFlags;
 use paging::temporary_page::TemporaryPage;
 use context::{self, Context};
 use context::memory::Grant;
@@ -100,9 +101,9 @@ impl UserInner {
             let full_size = ((offset + size + 4095)/4096) * 4096;
             let mut to_address = ::USER_GRANT_OFFSET;
 
-            let mut flags = entry::PRESENT | entry::NO_EXECUTE | entry::USER_ACCESSIBLE;
+            let mut flags = EntryFlags::PRESENT | EntryFlags::NO_EXECUTE | EntryFlags::USER_ACCESSIBLE;
             if writable {
-                flags |= entry::WRITABLE;
+                flags |= EntryFlags::WRITABLE;
             }
 
             for i in 0 .. grants.len() {

--- a/src/syscall/driver.rs
+++ b/src/syscall/driver.rs
@@ -1,6 +1,7 @@
 use interrupt::syscall::SyscallStack;
 use memory::{allocate_frames, deallocate_frames, Frame};
-use paging::{entry, ActivePageTable, PhysicalAddress, VirtualAddress};
+use paging::{ActivePageTable, PhysicalAddress, VirtualAddress};
+use paging::entry::EntryFlags;
 use context;
 use context::memory::Grant;
 use syscall::error::{Error, EFAULT, EINVAL, ENOMEM, EPERM, ESRCH, Result};
@@ -61,12 +62,12 @@ pub fn physmap(physical_address: usize, size: usize, flags: usize) -> Result<usi
         let full_size = ((offset + size + 4095)/4096) * 4096;
         let mut to_address = ::USER_GRANT_OFFSET;
 
-        let mut entry_flags = entry::PRESENT | entry::NO_EXECUTE | entry::USER_ACCESSIBLE;
+        let mut entry_flags = EntryFlags::PRESENT | EntryFlags::NO_EXECUTE | EntryFlags::USER_ACCESSIBLE;
         if flags & MAP_WRITE == MAP_WRITE {
-            entry_flags |= entry::WRITABLE;
+            entry_flags |= EntryFlags::WRITABLE;
         }
         if flags & MAP_WRITE_COMBINE == MAP_WRITE_COMBINE {
-            entry_flags |= entry::HUGE_PAGE;
+            entry_flags |= EntryFlags::HUGE_PAGE;
         }
 
         for i in 0 .. grants.len() {

--- a/src/syscall/validate.rs
+++ b/src/syscall/validate.rs
@@ -1,9 +1,10 @@
 use core::{mem, slice};
 
-use paging::{ActivePageTable, Page, VirtualAddress, entry};
+use paging::{ActivePageTable, Page, VirtualAddress};
+use paging::entry::EntryFlags;
 use syscall::error::*;
 
-fn validate(address: usize, size: usize, flags: entry::EntryFlags) -> Result<()> {
+fn validate(address: usize, size: usize, flags: EntryFlags) -> Result<()> {
     let active_table = unsafe { ActivePageTable::new() };
 
     let start_page = Page::containing_address(VirtualAddress::new(address));
@@ -28,7 +29,7 @@ pub fn validate_slice<T>(ptr: *const T, len: usize) -> Result<&'static [T]> {
     if len == 0 {
         Ok(&[])
     } else {
-        validate(ptr as usize, len * mem::size_of::<T>(), entry::PRESENT /* TODO | entry::USER_ACCESSIBLE */)?;
+        validate(ptr as usize, len * mem::size_of::<T>(), EntryFlags::PRESENT /* TODO | EntryFlags::USER_ACCESSIBLE */)?;
         Ok(unsafe { slice::from_raw_parts(ptr, len) })
     }
 }
@@ -38,7 +39,7 @@ pub fn validate_slice_mut<T>(ptr: *mut T, len: usize) -> Result<&'static mut [T]
     if len == 0 {
         Ok(&mut [])
     } else {
-        validate(ptr as usize, len * mem::size_of::<T>(), entry::PRESENT | entry::WRITABLE /* TODO | entry::USER_ACCESSIBLE */)?;
+        validate(ptr as usize, len * mem::size_of::<T>(), EntryFlags::PRESENT | EntryFlags::WRITABLE /* TODO | EntryFlags::USER_ACCESSIBLE */)?;
         Ok(unsafe { slice::from_raw_parts_mut(ptr, len) })
     }
 }


### PR DESCRIPTION
This pull request updates the `bitflags` crate to version 1.

The major change is that `bitflags` now uses associated constants, so the uses of the various constants had to be prefixed with the `bitflags` structure.