### PR TITLE
Do not discard .debug section

### DIFF
--- a/linkers/x86_64.ld
+++ b/linkers/x86_64.ld
@@ -51,7 +51,6 @@ SECTIONS {
 
     /DISCARD/ : {
         *(.comment*)
-        *(.debug*)
         *(.eh_frame*)
         *(.gcc_except_table*)
         *(.note*)


### PR DESCRIPTION
Do not discard the .debug section. If the builder would like to discard
this section, they can do so explicitly with objcopy.