### PR TITLE
Page table optimization

### DIFF
--- a/src/arch/x86_64/paging/entry.rs
+++ b/src/arch/x86_64/paging/entry.rs
@@ -29,12 +29,12 @@ pub const COUNTER_MASK: u64 = 0x3ff00000_00000000;
 impl Entry {
     /// Is the entry unused?
     pub fn is_unused(&self) -> bool {
-        self.0 == 0
+        self.0 == (self.0 & COUNTER_MASK)
     }
 
     /// Make the entry unused
     pub fn set_unused(&mut self) {
-        self.0 = 0;
+        self.0 = self.0 & COUNTER_MASK;
     }
 
     /// Get the address this page references

--- a/src/arch/x86_64/paging/entry.rs
+++ b/src/arch/x86_64/paging/entry.rs
@@ -67,6 +67,6 @@ impl Entry {
 
     /// Set bits 52-61 in entry, used as counter for page table    
     pub fn set_counter_bits(&mut self, count: u64) {
-        self.0 = ((self.0 & 0xc00fffff_ffffffff) | (count << 52));
+        self.0 = (self.0 & 0xc00fffff_ffffffff) | (count << 52);
     }
 }

--- a/src/arch/x86_64/paging/entry.rs
+++ b/src/arch/x86_64/paging/entry.rs
@@ -24,14 +24,14 @@ bitflags! {
 }
 
 pub const ADDRESS_MASK: usize = 0x000f_ffff_ffff_f000;
-pub const COUNTER_MASK: u64 = 0x3ff00000_00000000;
+pub const COUNTER_MASK: u64 = 0x3ff0_0000_0000_0000;
 
 impl Entry {
-    /// Zero entry
+    /// Clear entry
     pub fn set_zero(&mut self) {
         self.0 = 0;
     }
-    
+
     /// Is the entry unused?
     pub fn is_unused(&self) -> bool {
         self.0 == (self.0 & COUNTER_MASK)

--- a/src/arch/x86_64/paging/entry.rs
+++ b/src/arch/x86_64/paging/entry.rs
@@ -24,6 +24,7 @@ bitflags! {
 }
 
 pub const ADDRESS_MASK: usize = 0x000f_ffff_ffff_f000;
+pub const COUNTER_MASK: u64 = 0x3ff00000_00000000;
 
 impl Entry {
     /// Is the entry unused?
@@ -57,16 +58,16 @@ impl Entry {
 
     pub fn set(&mut self, frame: Frame, flags: EntryFlags) {
         debug_assert!(frame.start_address().get() & !ADDRESS_MASK == 0);
-        self.0 = (frame.start_address().get() as u64) | flags.bits();
+        self.0 = (frame.start_address().get() as u64) | flags.bits() | (self.0 & COUNTER_MASK);
     }
 
     /// Get bits 52-61 in entry, used as counter for page table
     pub fn counter_bits(&self) -> u64 {
-        (self.0 & 0x3ff00000_00000000) >> 52
+        (self.0 & COUNTER_MASK) >> 52
     }
 
     /// Set bits 52-61 in entry, used as counter for page table    
     pub fn set_counter_bits(&mut self, count: u64) {
-        self.0 = (self.0 & 0xc00fffff_ffffffff) | (count << 52);
+        self.0 = (self.0 & !COUNTER_MASK) | (count << 52);
     }
 }

--- a/src/arch/x86_64/paging/entry.rs
+++ b/src/arch/x86_64/paging/entry.rs
@@ -59,4 +59,14 @@ impl Entry {
         debug_assert!(frame.start_address().get() & !ADDRESS_MASK == 0);
         self.0 = (frame.start_address().get() as u64) | flags.bits();
     }
+
+    /// Get bits 52-61 in entry, used as counter for page table
+    pub fn counter_bits(&self) -> u64 {
+        (self.0 & 0x3ff00000_00000000) >> 52
+    }
+
+    /// Set bits 52-61 in entry, used as counter for page table    
+    pub fn set_counter_bits(&mut self, count: u64) {
+        self.0 = ((self.0 & 0xc00fffff_ffffffff) | (count << 52));
+    }
 }

--- a/src/arch/x86_64/paging/entry.rs
+++ b/src/arch/x86_64/paging/entry.rs
@@ -27,6 +27,11 @@ pub const ADDRESS_MASK: usize = 0x000f_ffff_ffff_f000;
 pub const COUNTER_MASK: u64 = 0x3ff00000_00000000;
 
 impl Entry {
+    /// Zero entry
+    pub fn set_zero(&mut self) {
+        self.0 = 0;
+    }
+    
     /// Is the entry unused?
     pub fn is_unused(&self) -> bool {
         self.0 == (self.0 & COUNTER_MASK)

--- a/src/arch/x86_64/paging/table.rs
+++ b/src/arch/x86_64/paging/table.rs
@@ -55,7 +55,7 @@ impl<L> Table<L> where L: TableLevel {
 
     pub fn zero(&mut self) {
         for entry in self.entries.iter_mut() {
-            entry.set_unused();
+            entry.set_zero();
         }
     }
 

--- a/src/arch/x86_64/paging/table.rs
+++ b/src/arch/x86_64/paging/table.rs
@@ -61,7 +61,7 @@ impl<L> Table<L> where L: TableLevel {
 
     /// Set number of entries in first table entry
     fn set_entry_count(&mut self, count: u64) {
-        assert!(count <= ENTRY_COUNT, "count can't be greater than ENTRY_COUNT");
+        assert!(count <= ENTRY_COUNT as u64, "count can't be greater than ENTRY_COUNT");
         self.entries[0].set_counter_bits(count);
     }
 

--- a/src/arch/x86_64/paging/table.rs
+++ b/src/arch/x86_64/paging/table.rs
@@ -61,7 +61,7 @@ impl<L> Table<L> where L: TableLevel {
 
     /// Set number of entries in first table entry
     fn set_entry_count(&mut self, count: u64) {
-        assert!(count <= ENTRY_COUNT as u64, "count can't be greater than ENTRY_COUNT");
+        debug_assert!(count <= ENTRY_COUNT as u64, "count can't be greater than ENTRY_COUNT");
         self.entries[0].set_counter_bits(count);
     }
 

--- a/src/arch/x86_64/paging/table.rs
+++ b/src/arch/x86_64/paging/table.rs
@@ -46,10 +46,8 @@ pub struct Table<L: TableLevel> {
 
 impl<L> Table<L> where L: TableLevel {
     pub fn is_unused(&self) -> bool {
-        for entry in self.entries.iter() {
-            if ! entry.is_unused() {
-                return false;
-            }
+        if self.entry_count() > 0 {
+            return false;
         }
 
         true
@@ -59,6 +57,27 @@ impl<L> Table<L> where L: TableLevel {
         for entry in self.entries.iter_mut() {
             entry.set_unused();
         }
+    }
+
+    /// Set number of entries in first table entry
+    fn set_entry_count(&mut self, count: u64) {
+        assert!(count <= ENTRY_COUNT, "count can't be greater than ENTRY_COUNT");
+        self.entries[0].set_counter_bits(count);
+    }
+
+    /// Get number of entries in first table entry
+    fn entry_count(&self) -> u64 {
+        self.entries[0].counter_bits()
+    }
+
+    pub fn increment_entry_count(&mut self) {
+        let current_count = self.entry_count();
+        self.set_entry_count(current_count + 1);
+    }
+
+    pub fn decrement_entry_count(&mut self) {
+        let current_count = self.entry_count();
+        self.set_entry_count(current_count - 1);
     }
 }
 
@@ -76,6 +95,7 @@ impl<L> Table<L> where L: HierarchicalLevel {
             assert!(!self[index].flags().contains(EntryFlags::HUGE_PAGE),
                     "next_table_create does not support huge pages");
             let frame = allocate_frames(1).expect("no frames available");
+            self.increment_entry_count();
             self[index].set(frame, EntryFlags::PRESENT | EntryFlags::WRITABLE | EntryFlags::USER_ACCESSIBLE /* Allow users to go down the page table, implement permissions at the page level */);
             self.next_table_mut(index).unwrap().zero();
         }


### PR DESCRIPTION
Use unused bits 51-61 in first entries of each page table as a counter for used entries.
I also removed unnecessary checks in unmap_inner.
After this change checking if page table is empty is a O(1) operation instead of O(N), where N is the number of entries.