### PR TITLE
Use slab allocator for kernel heap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ path = "src/lib.rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-alloc_kernel = { path = "alloc_kernel" }
 bitflags = "1"
 clippy = { version = "*", optional = true }
+slab_allocator = "0.3.0"
 spin = "0.4"
 raw-cpuid = "3.0"
 redox_syscall = { path = "syscall" }

--- a/alloc_kernel/Cargo.toml
+++ b/alloc_kernel/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-authors = ["Philipp Oppermann <dev@phil-opp.com>"]
-name = "alloc_kernel"
-version = "0.1.0"
-
-[dependencies]
-linked_list_allocator = { git = "https://github.com/redox-os/linked-list-allocator.git" }
-spin = "*"

--- a/src/arch/x86_64/start.rs
+++ b/src/arch/x86_64/start.rs
@@ -7,13 +7,13 @@ use core::slice;
 use core::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
 use acpi;
-use allocator;
 use arch::x86_64::pti;
 use device;
 use gdt;
 use idt;
 use interrupt;
 use memory;
+use memory::slab as allocator;
 use paging::{self, Page, VirtualAddress};
 use paging::entry::EntryFlags;
 use paging::mapper::MapperFlushAll;
@@ -113,7 +113,7 @@ pub unsafe extern fn kstart(args_ptr: *const KernelArgs) -> ! {
             flush_all.flush(&mut active_table);
 
             // Init the allocator
-            allocator::init(::KERNEL_HEAP_OFFSET, ::KERNEL_HEAP_SIZE);
+            allocator::init_heap(::KERNEL_HEAP_OFFSET, ::KERNEL_HEAP_SIZE);
         }
 
         // Initialize devices

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@
 #![feature(const_size_of)]
 #![no_std]
 
-extern crate alloc_kernel as allocator;
 pub extern crate x86;
 
 #[macro_use]
@@ -42,6 +41,7 @@ extern crate alloc;
 extern crate bitflags;
 extern crate goblin;
 extern crate spin;
+extern crate slab_allocator;
 
 use alloc::arc::Arc;
 use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
@@ -103,7 +103,7 @@ pub mod time;
 pub mod tests;
 
 #[global_allocator]
-static ALLOCATOR: allocator::Allocator = allocator::Allocator;
+static ALLOCATOR: memory::slab::Allocator = memory::slab::Allocator;
 
 /// A unique number that identifies the current CPU - used for scheduling
 #[thread_local]

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -10,6 +10,7 @@ use spin::Mutex;
 
 pub mod bump;
 pub mod recycle;
+pub mod slab;
 
 /// The current memory map. It's size is maxed out to 512 entries, due to it being
 /// from 0x500 to 0x5000 (800 is the absolute total)


### PR DESCRIPTION
Changes current linked list allocator for slab allocator.
Allocations <= 4096 bytes are made in fixed size blocks, >4096 bytes use current allocator.

Here are the benchmark results:
```
test allocate_many_small_blocks_linked_list            ... bench:   8,904,698 ns/iter (+/- 523,010)
test allocate_many_small_blocks_slab                   ... bench:   2,884,013 ns/iter (+/- 120,920)
test allocate_multiple_sizes_linked_list_over_4096     ... bench:       2,151 ns/iter (+/- 166)
test allocate_multiple_sizes_linked_list_up_to_4096    ... bench:      23,771 ns/iter (+/- 1,712)
test allocate_multiple_sizes_linked_list_various_sizes ... bench:       7,120 ns/iter (+/- 606)
test allocate_multiple_sizes_slab_over_4096            ... bench:       2,240 ns/iter (+/- 83)
test allocate_multiple_sizes_slab_up_to_4096           ... bench:      15,849 ns/iter (+/- 808)
test allocate_multiple_sizes_slab_various_sizes        ... bench:       5,495 ns/iter (+/- 245)
```
This allocator gives about 40% speedup for small allocations.
Slabs can grow using non-contiguous memory, space for allocations >4096 bytes also can grow, but new memory has to be directly after the old one.

Benchmark can be found here: https://github.com/weclaw1/allocator-benchmark