### PR TITLE
Fix TODO: Use triple fault to guarantee reboot

### DIFF
--- a/src/arch/x86_64/stop.rs
+++ b/src/arch/x86_64/stop.rs
@@ -14,7 +14,10 @@ pub unsafe extern fn kreset() -> ! {
         port.write(0xFE);
     }
 
-    // TODO: Use triple fault to guarantee reset
+    // Use triple fault to guarantee reset
+    asm!("cli" : : : : "intel", "volatile");
+    asm!("lidt cs:0" : : : : "intel", "volatile");
+    asm!("int $$3" : : : : "intel", "volatile");
 
     unreachable!();
 }


### PR DESCRIPTION
Cause interrupt, since the IDT is dorked we can't find the INT 3
handler (double fault), and the double fault handler can't be
found (triple fault).