### PR TITLE
Unique<T>: Data race allowed on T 

### DIFF
--- a/src/common/unique.rs
+++ b/src/common/unique.rs
@@ -12,8 +12,8 @@ impl<T> Clone for Unique<T> {
         *self
     }
 }
-unsafe impl<T> Send for Unique<T> {}
-unsafe impl<T> Sync for Unique<T> {}
+unsafe impl<T: Send> Send for Unique<T> {}
+unsafe impl<T: Sync> Sync for Unique<T> {}
 
 impl<T> Unique<T> {
     pub fn new(ptr: *mut T) -> Self {


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`Unique<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.

https://github.com/redox-os/kernel/blob/7269f9c6f19956017ce36484937d358b8fa1299c/src/common/unique.rs#L15-L16